### PR TITLE
fix(ci): resolve Ruff lint errors and enable static checks in CI

### DIFF
--- a/tests/smoke/test_login_factory.py
+++ b/tests/smoke/test_login_factory.py
@@ -1,10 +1,9 @@
 # tests/smoke/test_login_factory.py
 import os
-from playwright.sync_api import expect
 
 def test_login_factory_smoke(login_factory):
     page = login_factory("profile1")
-    base_url = os.getenv("AVITO_BASE_URL", "https://www.avito.ru").rstrip()
+    base_url = os.getenv("AVITO_BASE_URL", "https://www.avito.ru")
     page.goto(f"{base_url}/profile")
 
     assert "profile" in page.url.lower()


### PR DESCRIPTION
- Remove unused import in test_login_factory.py
- Fix f-strings without placeholders
- Add `# ruff: noqa: E402` to bootstrap_auth.py (path setup required before local imports)
- Add ruff and mypy to requirements.txt
- CI now passes lint, types, unit, and test collection

Complies with GitHub Playbook static health requirements (strict where feasible).